### PR TITLE
ci: Split build and release jobs into separate workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,43 +6,42 @@ on:
     branches:
       - main
 
+env:
+  IMAGE_NAME: ghcr.io/gostamp/image-tools
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # pin@v2
 
       - name: Build
-        run: make ci-build
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3
+        with:
+          load: true
+          context: .
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.IMAGE_NAME }}:latest
+          cache-to: |
+            type=gha,mode=max
+          tags: ${{ env.IMAGE_NAME }}:latest
+
+      - name: Inspect
+        run: make inspect
 
       - name: Test
         run: make test
 
       - name: Lint
         run: make lint
-
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Release
-        run: make ci-push APP_TAG=latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: build
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/gostamp/image-tools
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # pin@v2
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # pin@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Log in to the container registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3
+        with:
+          push: true
+          context: .
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.IMAGE_NAME }}:latest
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=${{ env.IMAGE_NAME }}:latest,mode=max
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Inspect
+        run: make inspect

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -15,6 +15,7 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest
+
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -35,7 +36,6 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
 
           # Publish the results for public repositories to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.

--- a/Makefile
+++ b/Makefile
@@ -18,28 +18,28 @@ SHELL := /bin/bash
 
 .PHONY: build
 build: ## Build the app
-	docker-compose build app
+	docker compose build app
 
 .PHONY: inspect
 inspect:
-	docker inspect $$(docker-compose config --images app)
+	docker inspect $$(docker compose config --images app)
 
 .PHONY: run
 run: ## Run the app
-	docker-compose run --rm app ./bin/command.sh
+	docker compose run --rm app ./bin/command.sh
 
 .PHONY: test
 test: APP_ENV := test
 test: ## Test the app
-	docker-compose run --rm app ./bin/test.sh
+	docker compose run --rm app ./bin/test.sh
 
 .PHONY: lint
 lint: ## Lint the app
-	docker-compose run --rm app ./bin/lint.sh
+	docker compose run --rm app ./bin/lint.sh
 
 .PHONY: clean
 clean: ## Clean the app
-	docker-compose down -v
+	docker compose down -v
 	rm -f .env
 
 
@@ -52,7 +52,7 @@ setup: ## Setup everything needed for local development
 
 .PHONY: shell
 shell: ## Shell into the container
-	docker-compose run --rm app bash
+	docker compose run --rm app bash
 
 # Via https://www.thapaliya.com/en/writings/well-documented-makefiles/
 # Note: The `##@` comments determine grouping

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,6 @@ export $(shell sed 's/=.*//' .env)
 export COMPOSE_DOCKER_CLI_BUILD := 1
 export DOCKER_BUILDKIT := 1
 
-# Defaults for GH actions
-ifeq ($(GITHUB_ACTIONS),true)
-  export APP_TAG := $(GITHUB_SHA)
-endif
-
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
 
@@ -24,6 +19,10 @@ SHELL := /bin/bash
 .PHONY: build
 build: ## Build the app
 	docker-compose build app
+
+.PHONY: inspect
+inspect:
+	docker inspect $$(docker-compose config --images app)
 
 .PHONY: run
 run: ## Run the app
@@ -42,17 +41,6 @@ lint: ## Lint the app
 clean: ## Clean the app
 	docker-compose down -v
 	rm -f .env
-
-
-##@ CI
-
-.PHONY: ci-build
-ci-build: ## Build the docker image
-	docker buildx bake --load --set app.platform=linux/amd64
-
-.PHONY: ci-push
-ci-push: ## Push the docker image to the registry
-	docker buildx bake --push
 
 
 ##@ Other

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,17 +6,8 @@ services:
     image: ${APP_REGISTRY}/${APP_NAME}:${APP_TAG}
     build:
       cache_from:
-        - ${APP_REGISTRY}/${APP_NAME}:latest
+        - ${APP_REGISTRY}/${APP_NAME}:${APP_TAG}
       context: .
-      # These only get used when running `docker buildx bake` (in CI).
-      x-bake:
-        cache-from:
-          - type=gha,scope=buildkit
-        cache-to:
-          - type=gha,scope=buildkit,mode=max
-        platforms:
-          - linux/amd64
-          - linux/arm64
     environment:
       - APP_ENV
       - APP_NAME


### PR DESCRIPTION
Also:

- Use the official docker actions rather than our make task. The [scorecard](https://github.com/ossf/scorecard) workflow doesn't like seeing other workflows that use elevated permissions combined with unknown/untrusted run commands (which I sort of understand). I don't know if there's a way to flag the make task as "trusted", and frankly I don't really want to invest the time 🤷 . Should address:
  - https://github.com/gostamp/docker-image-tools/security/code-scanning/10

- Set an explicit top-level permission. I have token permissions limited at the org level, but I guess scorecards can't see that, so adding a redundant permission config to make it happy. Should address:
  - https://github.com/gostamp/docker-image-tools/security/code-scanning/9

- Pinned action versions using [pin-github-action](https://github.com/mheap/pin-github-action). Need to figure out a way to automate and lint this.
